### PR TITLE
Feature/#2implement-audio-recorder-to-main

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,42 @@ python -m vrchat-recorder -d <directory>
 - `--obs_websocket_password <password>`:
   OBS StudioのWebsocketのパスワードを指定します。WebSocketServerの認証設定をしていない場合は指定する必要はありません。
 
+- `--mic_device_name <name>`, `--mic <name>`:
+  録音するマイクのデバイス名を指定します。デフォルトではデフォルトのマイクを使用します。
+
+- `mic_sample_rate <rate>`:
+  録音するマイクのサンプリングレートを指定します。デフォルトでは`44100`です。
+
+- `--mic_channels <channels>`:
+  録音するマイクのチャンネル数を指定します。デフォルトでは`1`です。
+
+- `--mic_block_size <size>`:
+  録音するマイクのブロック(チャンク)サイズを指定します。デフォルトでは`4096`です。
+
+- `--mic_flush_interval <interval>`:
+  ファイルへ一度にフラッシュするブロックの数です。デフォルトでは`100`です。
+
+- `--mic_subtype <subtype>`:
+  録音する音声ファイルのサブタイプを指定します。デフォルトでは`PCM_16`です。
+
+- `--speaker_device_name <name>`, `--speaker <name>`:
+  録音するスピーカーのデバイス名を指定します。デフォルトではデフォルトのスピーカーを使用します。
+
+- `--speaker_sample_rate <rate>`:
+  録音するスピーカーのサンプリングレートを指定します。デフォルトでは`44100`です。
+
+- `--speaker_channels <channels>`:
+  録音するスピーカーのチャンネル数を指定します。デフォルトでは`2`です。
+
+- `--speaker_block_size <size>`:
+  録音するスピーカーのブロック(チャンク)サイズを指定します。デフォルトでは`4096`です
+
+- `--speaker_flush_interval <interval>`:
+  ファイルへ一度にフラッシュするブロックの数です。デフォルトでは`100`です。
+
+- `--speaker_subtype <subtype>`:
+  録音する音声ファイルのサブタイプを指定します。デフォルトでは`PCM_16`です。
+
 - `--no_osc_feedback`:
   OSCフィードバックを記録しない場合は指定します。デフォルトでは記録します。
 
@@ -104,6 +140,12 @@ python -m vrchat-recorder -d <directory>
 
 - `--no_obs`:
   OBSを用いてプレイ映像および音声を録画しない場合は指定します。デフォルトでは記録します。
+
+- `--no_mic`:
+  マイクを用いて音声を録音しない場合は指定します。デフォルトでは記録します。
+
+- `--no_speaker`:
+  スピーカーを用いて音声を録音しない場合は指定します。デフォルトでは記録します。
 
 ## 開発途中
 

--- a/demos/audio_recording.py
+++ b/demos/audio_recording.py
@@ -1,8 +1,9 @@
-from vrchat_recorder.audio import MicRecorder, SpeakerRecorder
-
-from pathlib import Path
 import time
+from pathlib import Path
+
 import soundcard as sc
+
+from vrchat_recorder.audio import MicRecorder, SpeakerRecorder
 
 output_dir = Path(__file__).parent / "output"
 output_dir.mkdir(exist_ok=True)
@@ -11,20 +12,11 @@ mic_output_path = output_dir / "demo_mic_recording_%Y-%m-%d-%H-%M-%S-%f.wav"
 speaker_output_path = output_dir / "demo_speaker_recording_%Y-%m-%d-%H-%M-%S-%f.wav"
 
 
-
 mic_recorder = MicRecorder(
-    str(mic_output_path), 
-    sc.default_microphone().name, 
-    sample_rate=44100, 
-    block_size=4096, 
-    num_channels=1
+    str(mic_output_path), sc.default_microphone().name, sample_rate=44100, block_size=4096, num_channels=1
 )
 speaker_recorder = SpeakerRecorder(
-    str(speaker_output_path), 
-    sc.default_speaker().name,
-    sample_rate=44100, 
-    block_size=4096, 
-    num_channels=2
+    str(speaker_output_path), sc.default_speaker().name, sample_rate=44100, block_size=4096, num_channels=2
 )
 
 

--- a/demos/audio_recording.py
+++ b/demos/audio_recording.py
@@ -1,0 +1,44 @@
+from vrchat_recorder.audio import MicRecorder, SpeakerRecorder
+
+from pathlib import Path
+import time
+import soundcard as sc
+
+output_dir = Path(__file__).parent / "output"
+output_dir.mkdir(exist_ok=True)
+
+mic_output_path = output_dir / "demo_mic_recording_%Y-%m-%d-%H-%M-%S-%f.wav"
+speaker_output_path = output_dir / "demo_speaker_recording_%Y-%m-%d-%H-%M-%S-%f.wav"
+
+
+
+mic_recorder = MicRecorder(
+    str(mic_output_path), 
+    sc.default_microphone().name, 
+    sample_rate=44100, 
+    block_size=4096, 
+    num_channels=1
+)
+speaker_recorder = SpeakerRecorder(
+    str(speaker_output_path), 
+    sc.default_speaker().name,
+    sample_rate=44100, 
+    block_size=4096, 
+    num_channels=2
+)
+
+
+mic_recorder.record_background()
+speaker_recorder.record_background()
+
+print("Recording audios...")
+try:
+    while True:
+        time.sleep(1)
+except KeyboardInterrupt:
+    pass
+
+mic_recorder.shutdown()
+speaker_recorder.shutdown()
+
+print("Done.")

--- a/tests/test__main__.py
+++ b/tests/test__main__.py
@@ -5,6 +5,7 @@ from pytest_mock import MockerFixture
 
 from vrchat_recorder import confirm_preparation as confirm
 from vrchat_recorder.__main__ import main
+from vrchat_recorder.audio import MicRecorder, SpeakerRecorder
 from vrchat_recorder.gamepad_recorder import GamepadRecorder
 from vrchat_recorder.obs_video_recorder import OBSVideoRecorder
 from vrchat_recorder.osc_feedback_recorder import OSCFeedbackRecorder
@@ -17,6 +18,8 @@ def test_main(mocker: MockerFixture):
     mocker.patch.object(confirm, "confirm_about_vrchat", MagicMock())
     mocker.patch.object(confirm, "confirm_about_obs", MagicMock())
     mocker.patch.object(confirm, "confirm_about_controller", MagicMock())
+    mocker.patch.object(confirm, "confirm_about_mic", MagicMock())
+    mocker.patch.object(confirm, "confirm_about_speaker", MagicMock())
 
     # Mock GamepadRecorder
     mocker.patch.object(GamepadRecorder, "__init__", MagicMock(return_value=None))
@@ -38,6 +41,16 @@ def test_main(mocker: MockerFixture):
     mocker.patch.object(OBSVideoRecorder, "record_background", MagicMock())
     mocker.patch.object(OBSVideoRecorder, "shutdown", MagicMock())
 
+    # Mock MicRecorder
+    mocker.patch.object(MicRecorder, "__init__", MagicMock(return_value=None))
+    mocker.patch.object(MicRecorder, "record_background", MagicMock())
+    mocker.patch.object(MicRecorder, "shutdown", MagicMock())
+
+    # Mock SpeakerRecorder
+    mocker.patch.object(SpeakerRecorder, "__init__", MagicMock(return_value=None))
+    mocker.patch.object(SpeakerRecorder, "record_background", MagicMock())
+    mocker.patch.object(SpeakerRecorder, "shutdown", MagicMock())
+
     # Mock time.sleep to raise KeyboardInterrupt after the first call
     mocker.patch("time.sleep", MagicMock(side_effect=KeyboardInterrupt))
 
@@ -47,6 +60,8 @@ def test_main(mocker: MockerFixture):
     confirm.confirm_about_vrchat.assert_called_once()
     confirm.confirm_about_obs.assert_called_once()
     confirm.confirm_about_controller.assert_called_once()
+    confirm.confirm_about_mic.assert_called_once()
+    confirm.confirm_about_speaker.assert_called_once()
 
     # Assert that the recorders are initialized and their methods are called
     GamepadRecorder.__init__.assert_called_once()
@@ -60,3 +75,11 @@ def test_main(mocker: MockerFixture):
     OBSVideoRecorder.__init__.assert_called_once()
     OBSVideoRecorder.record_background.assert_called_once()
     OBSVideoRecorder.shutdown.assert_called_once()
+
+    MicRecorder.__init__.assert_called_once()
+    MicRecorder.record_background.assert_called_once()
+    MicRecorder.shutdown.assert_called_once()
+
+    SpeakerRecorder.__init__.assert_called_once()
+    SpeakerRecorder.record_background.assert_called_once()
+    SpeakerRecorder.shutdown.assert_called_once()

--- a/tests/test_argument_parser.py
+++ b/tests/test_argument_parser.py
@@ -21,6 +21,8 @@ def test_default_values(parser: ArgumentParser):
     assert not args.no_osc_feedback
     assert not args.no_gamepad
     assert not args.no_obs
+    assert not args.no_mic
+    assert not args.no_speaker
 
     assert args.vrchat_osc_ip == "localhost"
     assert args.vrchat_osc_port == 9001
@@ -30,6 +32,20 @@ def test_default_values(parser: ArgumentParser):
     assert args.obs_websocket_ip == "localhost"
     assert args.obs_websocket_port == 4444
     assert args.obs_websocket_password == "password"
+
+    assert args.mic_device_name is None
+    assert args.mic_sample_rate == 44100
+    assert args.mic_block_size == 4096
+    assert args.mic_channels == 1
+    assert args.mic_flush_interval == 100
+    assert args.mic_subtype == "PCM_16"
+
+    assert args.speaker_device_name is None
+    assert args.speaker_sample_rate == 44100
+    assert args.speaker_block_size == 4096
+    assert args.speaker_channels == 2
+    assert args.speaker_flush_interval == 100
+    assert args.speaker_subtype == "PCM_16"
 
 
 def test_custom_values(parser: ArgumentParser):
@@ -44,6 +60,8 @@ def test_custom_values(parser: ArgumentParser):
         "--no_osc_feedback",
         "--no_gamepad",
         "--no_obs",
+        "--no_mic",
+        "--no_speaker",
         "--vrchat_osc_ip",
         "192.168.1.1",
         "--vrchat_osc_port",
@@ -58,6 +76,30 @@ def test_custom_values(parser: ArgumentParser):
         "5000",
         "--obs_websocket_password",
         "custom_password",
+        "--mic_device_name",
+        "custom_mic_device_name",
+        "--mic_sample_rate",
+        "48000",
+        "--mic_block_size",
+        "2048",
+        "--mic_channels",
+        "2",
+        "--mic_flush_interval",
+        "200",
+        "--mic_subtype",
+        "PCM_24",
+        "--speaker_device_name",
+        "custom_speaker_device_name",
+        "--speaker_sample_rate",
+        "48000",
+        "--speaker_block_size",
+        "2048",
+        "--speaker_channels",
+        "2",
+        "--speaker_flush_interval",
+        "200",
+        "--speaker_subtype",
+        "PCM_24",
     ]
 
     args = parser.parse_args(custom_args)
@@ -70,6 +112,8 @@ def test_custom_values(parser: ArgumentParser):
     assert args.no_osc_feedback
     assert args.no_gamepad
     assert args.no_obs
+    assert args.no_mic
+    assert args.no_speaker
 
     assert args.vrchat_osc_ip == "192.168.1.1"
     assert args.vrchat_osc_port == 8000
@@ -79,3 +123,17 @@ def test_custom_values(parser: ArgumentParser):
     assert args.obs_websocket_ip == "10.0.0.1"
     assert args.obs_websocket_port == 5000
     assert args.obs_websocket_password == "custom_password"
+
+    assert args.mic_device_name == "custom_mic_device_name"
+    assert args.mic_sample_rate == 48000
+    assert args.mic_block_size == 2048
+    assert args.mic_channels == 2
+    assert args.mic_flush_interval == 200
+    assert args.mic_subtype == "PCM_24"
+
+    assert args.speaker_device_name == "custom_speaker_device_name"
+    assert args.speaker_sample_rate == 48000
+    assert args.speaker_block_size == 2048
+    assert args.speaker_channels == 2
+    assert args.speaker_flush_interval == 200
+    assert args.speaker_subtype == "PCM_24"

--- a/tests/test_confirm_preparation.py
+++ b/tests/test_confirm_preparation.py
@@ -49,3 +49,22 @@ def test_confirm_about_controller(mocker: MockerFixture) -> None:
 
     # Check if the input function was called
     mock_input.assert_called_once()
+
+
+def test_confirm_about_mic(mocker: MockerFixture) -> None:
+    # Mock the input and print functions
+    mock_input = mocker.patch("builtins.input", return_value="")
+    mock_print = mocker.patch("builtins.print")
+    mock_soundcard = mocker.patch("soundcard.all_microphones", return_value=[])
+
+    # Call the confirm_about_mic function
+    mod.confirm_about_mic("Microphone", 48000, 2)
+
+    # Check if the print function was called with the correct arguments
+    mock_print.assert_called_once_with(mod.confirm_about_mic_prompt.format("Microphone", 48000, 2, ""), end="")
+
+    # Check if the input function was called
+    mock_input.assert_called_once()
+
+    # Check if the soundcard.all_microphones function was called
+    mock_soundcard.assert_called_once()

--- a/tests/test_confirm_preparation.py
+++ b/tests/test_confirm_preparation.py
@@ -68,3 +68,22 @@ def test_confirm_about_mic(mocker: MockerFixture) -> None:
 
     # Check if the soundcard.all_microphones function was called
     mock_soundcard.assert_called_once()
+
+
+def test_confirm_about_speaker(mocker: MockerFixture) -> None:
+    # Mock the functions
+    mock_input = mocker.patch("builtins.input", return_value="")
+    mock_print = mocker.patch("builtins.print")
+    mock_soundcard = mocker.patch("soundcard.all_microphones", return_value=[])
+
+    # Call the confirm_about_speaker function
+    mod.confirm_about_speaker("Speaker", 48000, 2)
+
+    # Check if the print function was called with the correct arguments
+    mock_print.assert_called_once_with(mod.confirm_about_speaker_prompt.format("Speaker", 48000, 2, ""), end="")
+
+    # Check if the input function was called
+    mock_input.assert_called_once()
+
+    # Check if the soundcard.all_microphones function was called
+    mock_soundcard.assert_called_once_with(include_loopback=True)

--- a/tests/test_data_constants.py
+++ b/tests/test_data_constants.py
@@ -23,6 +23,9 @@ def test_FileExtensions():
     assert FileExtensions.CONTROLLER == "ctrlr"
     assert FileExtensions.VIDEO == "video"
     assert FileExtensions.GAMEPAD == "gamepad"
+    assert FileExtensions.WAV == "wav"
+    assert FileExtensions.MICROPHONE == "mic"
+    assert FileExtensions.SPEAKER == "speaker"
 
 
 def test_DataTypeNames():

--- a/tests/test_name_utils.py
+++ b/tests/test_name_utils.py
@@ -5,8 +5,10 @@ import pytest
 from vrchat_recorder.data_constants import FileExtensions as FE
 from vrchat_recorder.name_utils import (
     get_gamepad_log_file_name,
+    get_mic_audio_file_name,
     get_obs_video_file_name,
     get_osc_feedback_log_file_name,
+    get_speaker_audio_file_name,
     get_vrcrec_dir_name,
 )
 
@@ -39,3 +41,13 @@ def test_get_osc_feedback_log_file_name(date_str):
 def test_get_obs_video_file_name(date_str):
     expected_obs_video_file_name = f"{date_str}.{FE.VIDEO}"
     assert get_obs_video_file_name(date_str) == expected_obs_video_file_name
+
+
+def test_get_mic_audio_file_name(date_str):
+    expected_mic_audio_file_name = f"{date_str}.{FE.MICROPHONE}.{FE.WAV}"
+    assert get_mic_audio_file_name(date_str) == expected_mic_audio_file_name
+
+
+def test_get_speaker_audio_file_name(date_str):
+    expected_speaker_audio_file_name = f"{date_str}.{FE.SPEAKER}.{FE.WAV}"
+    assert get_speaker_audio_file_name(date_str) == expected_speaker_audio_file_name

--- a/vrchat_recorder/argument_parser.py
+++ b/vrchat_recorder/argument_parser.py
@@ -13,6 +13,8 @@ def get_parser() -> ArgumentParser:
     parser = get_type_selection_parser(parser)
     parser = get_osc_feedback_parser(parser)
     parser = get_obs_parser(parser)
+    parser = get_mic_parser(parser)
+    parser = get_speaker_parser(parser)
 
     return parser
 
@@ -47,6 +49,8 @@ def get_type_selection_parser(parser: ArgumentParser) -> ArgumentParser:
     parser.add_argument("--no_osc_feedback", action="store_true", help="Do not record the OSC feedback.")
     parser.add_argument("--no_gamepad", action="store_true", help="Do not record the gamepad input.")
     parser.add_argument("--no_obs", action="store_true", help="Do not control OBS and play video is not recorded.")
+    parser.add_argument("--no_mic", action="store_true", help="Do not record the microphone.")
+    parser.add_argument("--no_speaker", action="store_true", help="Do not record the speaker.")
 
     return parser
 
@@ -83,5 +87,49 @@ def get_obs_parser(parser: ArgumentParser) -> ArgumentParser:
     parser.add_argument(
         "--obs_websocket_password", default="password", help="The password of the OBS websocket server."
     )
+
+    return parser
+
+
+def get_mic_parser(parser: ArgumentParser) -> ArgumentParser:
+    """Create a parser for the microphone recording.
+
+    Args:
+        parser (ArgumentParser): The base parser.
+
+    Returns:
+        parser (ArgumentParser): The argument parser for recording the microphone.
+    """
+
+    parser.add_argument("--mic_device_name", "--mic", default=None, help="The name of the microphone device.")
+    parser.add_argument("--mic_sample_rate", type=int, default=44100, help="The sample rate of the microphone.")
+    parser.add_argument("--mic_block_size", type=int, default=4096, help="The chunk size of the microphone.")
+    parser.add_argument("--mic_channels", type=int, default=1, help="The number of channels of the microphone.")
+    parser.add_argument(
+        "--mic_flush_interval", type=int, default=100, help="The number of blocks to flush to the file at once."
+    )
+    parser.add_argument("--mic_subtype", default="PCM_16", help="The subtype of the microphone recording data.")
+
+    return parser
+
+
+def get_speaker_parser(parser: ArgumentParser) -> ArgumentParser:
+    """Create a parser for the speaker recording.
+
+    Args:
+        parser (ArgumentParser): The base parser.
+
+    Returns:
+        parser (ArgumentParser): The argument parser for recording the speaker.
+    """
+
+    parser.add_argument("--speaker_device_name", "--speaker", default=None, help="The name of the speaker device.")
+    parser.add_argument("--speaker_sample_rate", type=int, default=44100, help="The sample rate of the speaker.")
+    parser.add_argument("--speaker_block_size", type=int, default=4096, help="The chunk size of the speaker.")
+    parser.add_argument("--speaker_channels", type=int, default=2, help="The number of channels of the speaker.")
+    parser.add_argument(
+        "--speaker_flush_interval", type=int, default=100, help="The number of blocks to flush to the file at once."
+    )
+    parser.add_argument("--speaker_subtype", default="PCM_16", help="The subtype of the speaker recording data.")
 
     return parser

--- a/vrchat_recorder/audio/__init__.py
+++ b/vrchat_recorder/audio/__init__.py
@@ -1,0 +1,2 @@
+from .mic_recorder import MicRecorder
+from .speaker_recorder import SpeakerRecorder

--- a/vrchat_recorder/confirm_preparation.py
+++ b/vrchat_recorder/confirm_preparation.py
@@ -39,6 +39,16 @@ confirm_about_mic_prompt = """\
 {3}
 """
 
+confirm_about_speaker_prompt = """\
+確認: スピーカー
+選択されたスピーカーのデバイス名は `{0}` で正しいですか？
+サンプリングレートは `{1}` で正しいですか？
+チャネル数は `{2}` で正しいですか？
+正しくない場合は次のデバイスリストから正しい名前を指定してください。
+スピーカーはループバックデバイスとして録音されます。
+{3}
+"""
+
 
 def confirm_about_obs(OBS_WEBSOCKET_IP: Any, OBS_WEBSOCKET_PORT: int) -> None:
     """Confirm about OBS.
@@ -80,4 +90,22 @@ def confirm_about_mic(mic_name: str, mic_sampling_rate: int, mic_channels: int) 
     """
     mic_names = "\n".join([f"{i}: {mic.name}" for i, mic in enumerate(sc.all_microphones())])
     print(confirm_about_mic_prompt.format(mic_name, mic_sampling_rate, mic_channels, mic_names), end="")
+    input()
+
+
+def confirm_about_speaker(speaker_name: str, speaker_sampling_rate: int, speaker_channels: int) -> None:
+    """Confirm about speaker.
+
+    Args:
+        speaker_name (str): Speaker name.
+        speaker_sampling_rate (int): Speaker sampling rate.
+        speaker_channels (int): Speaker channels.
+    """
+    speaker_names = "\n".join(
+        [f"{i}: {speaker.name}" for i, speaker in enumerate(sc.all_microphones(include_loopback=True))]
+    )
+    print(
+        confirm_about_speaker_prompt.format(speaker_name, speaker_sampling_rate, speaker_channels, speaker_names),
+        end="",
+    )
     input()

--- a/vrchat_recorder/confirm_preparation.py
+++ b/vrchat_recorder/confirm_preparation.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 import inputs
+import soundcard as sc
 
 confirm_about_obs_prompt = """\
 確認: OBS
@@ -27,6 +28,15 @@ confirm_about_controller_prompt = """\
 2. 現在表示しているデバイス一覧にあなたのGamepadは表示されていますか？
 デバイス一覧:
 {0}
+"""
+
+confirm_about_mic_prompt = """\
+確認: マイク
+選択されたマイクのデバイス名は `{0}` で正しいですか？
+サンプリングレートは `{1}` で正しいですか？
+チャネル数は `{2}` で正しいですか？
+正しくない場合は次のデバイスリストから正しい名前を指定してください。
+{3}
 """
 
 
@@ -57,4 +67,17 @@ def confirm_about_controller() -> None:
     """Confirm about controller."""
     controller_names = "\n".join([f"{i}: {controller.name}" for i, controller in enumerate(inputs.devices.gamepads)])
     print(confirm_about_controller_prompt.format(controller_names), end="")
+    input()
+
+
+def confirm_about_mic(mic_name: str, mic_sampling_rate: int, mic_channels: int) -> None:
+    """Confirm about microphone.
+
+    Args:
+        mic_name (str): Microphone name.
+        mic_sampling_rate (int): Microphone sampling rate.
+        mic_channels (int): Microphone channels.
+    """
+    mic_names = "\n".join([f"{i}: {mic.name}" for i, mic in enumerate(sc.all_microphones())])
+    print(confirm_about_mic_prompt.format(mic_name, mic_sampling_rate, mic_channels, mic_names), end="")
     input()

--- a/vrchat_recorder/data_constants.py
+++ b/vrchat_recorder/data_constants.py
@@ -24,6 +24,9 @@ class FileExtensions:
     CONTROLLER = "ctrlr"
     VIDEO = "video"
     GAMEPAD = "gamepad"
+    WAV = "wav"
+    MICROPHONE = "mic"
+    SPEAKER = "speaker"
 
 
 class DataTypeNames:

--- a/vrchat_recorder/name_utils.py
+++ b/vrchat_recorder/name_utils.py
@@ -54,3 +54,25 @@ def get_obs_video_file_name(date_str: str) -> str:
         obs video file name. (str): The name of the OBS video file.
     """
     return f"{date_str}.{FE.VIDEO}"
+
+
+def get_mic_audio_file_name(date_str: str) -> str:
+    """Get the name of the microphone audio file.
+    Args:
+        date_str: (str): The date string.
+
+    Returns:
+        microphone audio file name. (str): The name of the microphone audio file.
+    """
+    return f"{date_str}.{FE.MICROPHONE}.{FE.WAV}"
+
+
+def get_speaker_audio_file_name(date_str: str) -> str:
+    """Get the name of the speaker audio file.
+    Args:
+        date_str: (str): The date string.
+
+    Returns:
+        speaker audio file name. (str): The name of the speaker audio file.
+    """
+    return f"{date_str}.{FE.SPEAKER}.{FE.WAV}"


### PR DESCRIPTION
## 概要

#2 Mic Recorder と Speaker Recorderを`main`関数に追加

## 変更内容

- `__main__` に Mic/Speaker Recorderの起動処理を追加
- `argument_parser`にmicとspeakerのコマンドライン引数を追加
- `confirm_preparation`にMicとSpeakerを追加
- `data_constants`に新たなエクステンション定数を追加
- `name_utils`にファイルの名前の生成関数を追加
- READMEに新しく追加されたコマンドライン引数のドキュメントを追記
- 追加された機能のテストコードを実装
- MicとSpeaker Recorderのデモコードを`audio_recording.py`に実装

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make test`コマンドでローカルにテストしましたか?
- [x] `make format`コマンドで `pre-commit` フックを実行しましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
